### PR TITLE
fix: rename `environment` to `deploy_env` to avoid Ansible keyword conflict

### DIFF
--- a/env/supabase.yml
+++ b/env/supabase.yml
@@ -5,7 +5,7 @@
 ##########
 
 deploy_user: changeit # System user ( e.g. my_user if `pwd` shows /home/my_user) # REQUIRED
-environment: changeit # Container name suffix (e.g. prod, qa). Leave as changeit if not needed.
+deploy_env: changeit # Container name suffix (e.g. prod, qa). Leave as changeit if not needed.
 docker_users:
   - changeit # same as deploy_user #REQUIRED
 docker_restart: yes

--- a/roles/supabase/templates/docker-compose-supabase.yml.j2
+++ b/roles/supabase/templates/docker-compose-supabase.yml.j2
@@ -2,7 +2,7 @@ name: supabase
 
 services:
   studio:
-    container_name: supabase-studio{% if environment %}-{{ environment }}{% endif %}
+    container_name: supabase-studio{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
     image: {{ sb_studio_version }}
     restart: unless-stopped
     healthcheck:
@@ -51,7 +51,7 @@ services:
       - ./volumes/functions:/app/edge-functions:ro,z
 
   kong:
-    container_name: supabase-kong{% if environment %}-{{ environment }}{% endif %}
+    container_name: supabase-kong{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
     image: {{ sb_kong_version }}
     restart: unless-stopped
     networks:
@@ -100,7 +100,7 @@ services:
 
 
   auth:
-    container_name: supabase-auth{% if environment %}-{{ environment }}{% endif %}
+    container_name: supabase-auth{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
     image: {{ sb_gotrue_version }}
     restart: unless-stopped
     healthcheck:
@@ -254,7 +254,7 @@ services:
       # GOTRUE_HOOK_SEND_EMAIL_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
 
   rest:
-    container_name: supabase-rest{% if environment %}-{{ environment }}{% endif %}
+    container_name: supabase-rest{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
     image: {{ sb_rest_version }}
     restart: unless-stopped
     depends_on:
@@ -332,7 +332,7 @@ services:
 
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
-    container_name: supabase-storage{% if environment %}-{{ environment }}{% endif %}
+    container_name: supabase-storage{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
     image: {{ sb_storage_version }}
     restart: unless-stopped
     depends_on:
@@ -391,7 +391,7 @@ services:
       - ./volumes/storage:/var/lib/storage:z
 
   imgproxy:
-    container_name: supabase-imgproxy{% if environment %}-{{ environment }}{% endif %}
+    container_name: supabase-imgproxy{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
     image: {{ sb_imgproxy_version }}
     restart: unless-stopped
     volumes:
@@ -414,7 +414,7 @@ services:
       IMGPROXY_MAX_SRC_RESOLUTION: 16.8
 
   meta:
-    container_name: supabase-meta{% if environment %}-{{ environment }}{% endif %}
+    container_name: supabase-meta{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
     image: {{ sb_meta_version }}
     restart: unless-stopped
     depends_on:
@@ -431,7 +431,7 @@ services:
       CRYPTO_KEY: ${PG_META_CRYPTO_KEY}  
 
   functions:
-    container_name: supabase-edge-functions{% if environment %}-{{ environment }}{% endif %}
+    container_name: supabase-edge-functions{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
     image: {{ sb_functions_version }}
     restart: unless-stopped
     volumes:
@@ -470,7 +470,7 @@ services:
 
   # Comment out everything below this point if you are using an external Postgres database
   db:
-    container_name: supabase-db{% if environment %}-{{ environment }}{% endif %}
+    container_name: supabase-db{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
     image: {{ sb_db_version }}
     healthcheck:
       test: 
@@ -552,7 +552,7 @@ services:
 
 
   supavisor:
-    container_name: supabase-pooler{% if environment %}-{{ environment }}{% endif %}
+    container_name: supabase-pooler{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
     image: {{ sb_supavisor_version }}
     restart: unless-stopped
     ports:

--- a/roles/supabase/templates/docker-compose-supabase.yml.j2
+++ b/roles/supabase/templates/docker-compose-supabase.yml.j2
@@ -2,7 +2,7 @@ name: supabase
 
 services:
   studio:
-    container_name: supabase-studio{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
+    container_name: supabase-studio{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_studio_version }}
     restart: unless-stopped
     healthcheck:
@@ -51,7 +51,7 @@ services:
       - ./volumes/functions:/app/edge-functions:ro,z
 
   kong:
-    container_name: supabase-kong{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
+    container_name: supabase-kong{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_kong_version }}
     restart: unless-stopped
     networks:
@@ -100,7 +100,7 @@ services:
 
 
   auth:
-    container_name: supabase-auth{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
+    container_name: supabase-auth{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_gotrue_version }}
     restart: unless-stopped
     healthcheck:
@@ -254,7 +254,7 @@ services:
       # GOTRUE_HOOK_SEND_EMAIL_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
 
   rest:
-    container_name: supabase-rest{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
+    container_name: supabase-rest{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_rest_version }}
     restart: unless-stopped
     depends_on:
@@ -332,7 +332,7 @@ services:
 
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
-    container_name: supabase-storage{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
+    container_name: supabase-storage{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_storage_version }}
     restart: unless-stopped
     depends_on:
@@ -391,7 +391,7 @@ services:
       - ./volumes/storage:/var/lib/storage:z
 
   imgproxy:
-    container_name: supabase-imgproxy{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
+    container_name: supabase-imgproxy{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_imgproxy_version }}
     restart: unless-stopped
     volumes:
@@ -414,7 +414,7 @@ services:
       IMGPROXY_MAX_SRC_RESOLUTION: 16.8
 
   meta:
-    container_name: supabase-meta{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
+    container_name: supabase-meta{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_meta_version }}
     restart: unless-stopped
     depends_on:
@@ -431,7 +431,7 @@ services:
       CRYPTO_KEY: ${PG_META_CRYPTO_KEY}  
 
   functions:
-    container_name: supabase-edge-functions{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
+    container_name: supabase-edge-functions{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_functions_version }}
     restart: unless-stopped
     volumes:
@@ -470,7 +470,7 @@ services:
 
   # Comment out everything below this point if you are using an external Postgres database
   db:
-    container_name: supabase-db{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
+    container_name: supabase-db{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_db_version }}
     healthcheck:
       test: 
@@ -552,7 +552,7 @@ services:
 
 
   supavisor:
-    container_name: supabase-pooler{% if deploy_env != 'changeit' %}-{{ deploy_env }}{% endif %}
+    container_name: supabase-pooler{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_supavisor_version }}
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Problem

The variable `environment` clashes with Ansible's reserved play/task keyword. When used in Jinja2 templates, `{{ environment }}` resolves to an empty/undefined value instead of the user-defined string (e.g. `qa`), causing the container name suffix to never render.

Additionally, the condition `{% if environment %}` treats any non-empty string as truthy, so the default placeholder value `changeit` would incorrectly produce container names like `supabase-studio-changeit`.

## Changes

- **`env/supabase.yml`**: Renamed `environment` to `deploy_env` to avoid the keyword conflict.
- **`roles/supabase/templates/docker-compose-supabase.yml.j2`**: Updated all 10 `container_name` fields to use an inline conditional expression `{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}` instead of a `{% if %}` block tag, which also fixes a `trim_blocks` formatting issue where the `image:` line was rendered on the same line as `container_name:`.

## Behavior

| `deploy_env` value | Result |
|---|---|
| `changeit` (default) | `supabase-studio` |
| `qa` | `supabase-studio-qa` |
| `prod` | `supabase-studio-prod` |
