### PR TITLE
docs(readme): make secure full-featured setup the default install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Ansible Supabase
 
-One-command deployment of a **self-hosted Supabase stack** on any Debian/Ubuntu server. The playbook installs Docker, clones the latest Supabase release, generates all configuration files, and starts the full stack with a single command.
+One-command deployment of a **self-hosted, production-ready Supabase stack** on any Debian/Ubuntu server. The playbook installs Docker, clones the latest Supabase release, generates all configuration files, and starts the full stack — secured by default with automatic TLS, SSO/OAuth2, basic auth, IP allow-listing, a firewall, and brute-force protection.
 
-For production hardening (SSO, monitoring, firewall, backups, encryption) see [docs/advanced-docs.md](docs/advanced-docs.md).
+This repository's purpose is to give you a **ready-to-use, full-featured Supabase with security, encryption, and SSO/auth baked in** — not a bare dashboard exposed to the internet.
+
+> **Encryption at rest (LUKS) and automated S3 backups** are included and ready to enable; they need a dedicated disk volume and S3 credentials respectively, so they are shown as optional hardening steps at the end of this guide.
+
+For deep customization (custom OAuth providers, Grafana modes, retention tuning, version pinning) see [docs/advanced-docs.md](docs/advanced-docs.md).
 
 ---
 
@@ -11,8 +15,12 @@ For production hardening (SSO, monitoring, firewall, backups, encryption) see [d
 ### 1. 📋 Prerequisites
 
 - A **Debian/Ubuntu server** with root or sudo access
-- A **domain** with a DNS A record pointing to your server (e.g. `sb.example.com`)
-- Ports **80** and **443** reachable for auto Let's Encrypt TLS and reverse proxy
+- A **domain** with three DNS A records pointing to your server:
+  - `sb.example.com` — Supabase dashboard + API
+  - `auth.example.com` — OAuth2 authentication endpoint
+  - `monitor.example.com` — Grafana dashboard (monitoring is enabled by default)
+- Ports **80** and **443** reachable for automatic Let's Encrypt TLS and the Caddy reverse proxy
+- A registered **OAuth2 application** (GitHub, GitLab, Discord, or any OIDC provider) to protect the dashboard via SSO — see [SSO Provider Setup](#sso-provider-setup) below
 
 ### 2. 📥 Clone
 
@@ -27,11 +35,11 @@ cd ansible-supabase
 sh generate-keys.sh
 ```
 
-This updates `env/supabase.yml` with all Supabase keys (JWT, anon key, service role key, Postgres password, and all cryptographic tokens).
+This updates `env/supabase.yml` with all Supabase cryptographic secrets (JWT, anon key, service role key, Postgres password, and all tokens).
 
 ### 4. ⚙️ Configure `env/supabase.yml`
 
-Set the minimum required Supabase variables (every field tagged `#REQUIRED`):
+Open `env/supabase.yml` and fill in every field tagged `#REQUIRED`. The file ships with **secure defaults** (basic auth + IP allow-list + SSO on the dashboard). Keep them — do not strip them down.
 
 ```yaml
 # ── System User ──────────────────────────
@@ -39,7 +47,7 @@ deploy_user: your-ssh-username
 docker_users:
   - your-ssh-username
 
-# ── Supabase Secrets ( Auto generated from step 3) ──────
+# ── Supabase Secrets (auto-generated in step 3) ──────
 postgres_db_pwd: <strong-password>
 sb_jwt_secret: <jwt-secret-from-generator>
 sb_anon_key: <anon-key-from-generator>
@@ -56,6 +64,8 @@ pooler_tenant_id: pooler
 # ── Public URLs ──────────────────────────
 site_url: https://app.example.com          # Your app's public URL
 api_external_url: https://sb.example.com   # Supabase API endpoint (used by Studio)
+additional_redirect_urls: https://app.example.com/auth/callback
+mailer_templates_base_url: https://app.example.com
 
 # ── SMTP (for auth emails) ───────────────
 smtp_admin_email: user@example.com
@@ -64,20 +74,85 @@ smtp_user: user@example.com
 smtp_password: <smtp-password>
 ```
 
-#### Caddyfile Configuration (Reverse Proxy)
+#### SSO Provider Setup
 
-The Caddyfile configuration in `env/supabase.yml` defines how incoming requests are routed. For a minimal setup without SSO or basic auth, configure the `projects` section like this:
+Pick **one** OAuth2 provider and fill in its block in `env/supabase.yml`. Set `SSO_PROVIDER` to `github`, `gitlab`, `discord`, or `generic` (any OIDC).
+
+**GitHub** (redirect URI: `https://sb.example.com/oauth2/github/authorization-code-callback`):
+
+```yaml
+SSO_PROVIDER: github
+github_oauth_client_id: <your-client-id>
+github_oauth_client_secret: <your-client-secret>
+github_allow_list: "github.com/user1 github.com/user2"
+```
+
+**GitLab** (redirect URI: `https://sb.example.com/oauth2/gitlab/authorization-code-callback`):
+
+```yaml
+SSO_PROVIDER: gitlab
+gitlab_domain: gitlab.com
+gitlab_oauth_client_id: <your-client-id>
+gitlab_oauth_client_secret: <your-client-secret>
+gitlab_allow_list: "user1@example.com user2@example.com"
+```
+
+**Discord** (redirect URI: `https://sb.example.com/oauth2/discord/authorization-code-callback`):
+
+```yaml
+SSO_PROVIDER: discord
+discord_oauth_client_id: <your-client-id>
+discord_oauth_client_secret: <your-client-secret>
+admin_role_id: <your-admin-user-id>
+discord_guild_id: <your-discord-server-id>
+```
+
+**Generic OIDC** (any OpenID Connect provider, e.g. Keycloak):
+
+```yaml
+SSO_PROVIDER: generic
+oidc_realm: generic
+oidc_driver: generic
+oidc_client_id: <your-client-id>
+oidc_client_secret: <your-client-secret>
+base_auth_url: https://keycloak.example.com
+metadata_url: https://keycloak.example.com/.well-known/openid-configuration
+app_url: https://sb.example.com
+generic_allow_list: "user1@gmail.com user2@gmail.com"
+```
+
+**Common SSO variables** (required for any provider):
+
+```yaml
+base_auth_domain: auth.example.com    # OAuth2 auth endpoint subdomain
+root_domain: example.com              # root domain for SSO cookies
+jwt_shared_key: <openssl rand -base64 32>
+```
+
+#### 🛡️ Caddyfile Configuration (Reverse Proxy + SSO + Basic Auth)
+
+The `projects` block in `env/supabase.yml` is pre-configured to protect the dashboard with SSO, basic auth, and an IP allow-list. Keep this secure default:
 
 ```yaml
 projects:
   supabase:
     log_file: supabase-access
     domain: "sb.example.com"
+    allowed_ips:                       # IP allow-list — remove if you don't need it
+      - 123.123.123.123
+      - 111.111.111.111
+    oidc_enabled: true
     upstreams:
-      # Dashboard
+      # Dashboard — protected by SSO + basic auth
       - targets: ["localhost:3001"]
         paths: [""]
-      # API routes
+        oidc: true
+        basicauth:
+          - path: /project/default
+            username: your_user
+            # Generate with: caddy hash-password
+            password: $2a$10$...
+      # API routes — Kong handles auth, no SSO
       - targets: ["localhost:8000"]
         paths:
           - /rest/v1/*
@@ -85,11 +160,49 @@ projects:
           - /realtime/v1/*
           - /storage/v1/*
           - /functions/v1/*
+        oidc: false
+
+  monitor:
+    log_file: monitor-access
+    domain: "monitor.example.com"
+    oidc_enabled: false
+    upstreams:
+      - targets: ["localhost:3002"]
+        paths: [""]
+        oidc: false
 ```
 
-> **Note:** The existing `env/supabase.yml` includes basic auth and IP whitelisting for basic dashboard protection. You can keep that configuration for minimal access control, or replace it with the example above for an unprotected dashboard. For SSO and production-grade security, see [docs/advanced-docs.md](docs/advanced-docs.md).
+> To lock down Grafana, set `GRAFANA_AUTH_ANONYMOUS_ENABLED: false` and enable basic auth or GitHub OAuth for Grafana (see [docs/advanced-docs.md](docs/advanced-docs.md)).
 
-### 5. ▶️ Deploy
+#### 🧱 Firewall & Brute-force Protection
+
+The default `firewall_allow` / `firewall_deny` and fail2ban blocks in `env/supabase.yml` are already sane (allow 80/443 + SSH, deny internal ports). Adjust the `allowed_ips` and `firewall_allow` entries to your needs.
+
+### 5. 🧩 Enable the Security Roles
+
+The security roles ship commented in `playbook-supabase.yml`. **Uncomment them** so the default deploy includes the full security stack:
+
+```yaml
+---
+- hosts: localhost
+  become: true
+  roles:
+   - docker
+   - supabase
+
+   # ─── Security & monitoring (enabled by default) ───
+   - ufw                     # Firewall — allow/deny rules per port
+   - caddy                   # Reverse proxy + automatic TLS + SSO + basic auth
+   - fail2ban                # Brute-force protection for Postgres
+   - monitor                 # Grafana + Prometheus + Loki stack
+
+   # ─── Optional hardening (need external resources) ───
+   # - role: luks             # At-rest disk encryption (needs a dedicated volume)
+   #   when: supabase_encryption.enabled
+   # - backup                 # Automated S3-compatible backups (needs S3 creds)
+```
+
+### 6. ▶️ Deploy
 
 Run the installer (installs Ansible + Git if needed, then executes the playbook):
 
@@ -103,9 +216,39 @@ To see what will happen without making changes:
 sudo ./install.sh -d
 ```
 
+---
 
+## 🔒 Optional Hardening
 
-> **⚠️ Security Notice:** This minimal setup exposes the Supabase dashboard without any authentication. Anyone who can reach your server can access the Studio UI. For production deployments, enable basic auth, SSO, firewall rules, or the full Caddy reverse proxy — see [docs/advanced-docs.md](docs/advanced-docs.md).
+These two features are part of the complete stack but require external resources, so they are not enabled by default. Enable them for a fully hardened deployment.
+
+### At-rest Disk Encryption (LUKS)
+
+Encrypts a separate data volume for Postgres data with automatic unlock on boot. Set in `env/supabase.yml`:
+
+```yaml
+supabase_encryption:
+  enabled: true
+luks_device: /dev/disk/by-id/YOUR_VOLUME_NAME
+luks_mount_point: /data
+```
+
+Then uncomment the `luks` role in `playbook-supabase.yml` (see step 5).
+
+### Automated S3 Backups
+
+Dumps the database on a cron schedule and uploads to any S3-compatible storage. Set in `env/supabase.yml`:
+
+```yaml
+s3_remote_name: r2
+s3_provider: Cloudflare
+s3_access_key: <your-key>
+s3_secret_key: <your-secret>
+s3_endpoint: https://<your-endpoint>
+s3_bucket_name: supabase-backups
+```
+
+Then uncomment the `backup` role in `playbook-supabase.yml` (see step 5).
 
 ---
 
@@ -125,13 +268,15 @@ sudo ./install.sh -d
 | `db` | PostgreSQL 17 | 5432 |
 | `supavisor` | Connection Pooler | 6543 |
 
+Plus the security/monitoring stack: **Caddy** (reverse proxy + TLS + SSO), **UFW** firewall, **Fail2ban**, and **Grafana/Prometheus/Loki**.
+
 ---
 
 ## 📚 Advanced Features
 
 | Feature | Description |
 |---------|-------------|
-| **Caddy Reverse Proxy + SSO** | Automatic TLS, GitHub/GitLab/Discord OAuth2, basic auth, IP allow lists |
+| **Caddy Reverse Proxy + SSO** | Automatic TLS, GitHub/GitLab/Discord/Generic OIDC, basic auth, IP allow lists |
 | **Monitoring Stack** | Grafana, Prometheus, Loki, Node Exporter, cAdvisor, Postgres Exporter |
 | **LUKS Encryption** | At-rest disk encryption for Postgres data |
 | **S3 Backups** | Automated cron-based backups to S3-compatible storage |
@@ -145,4 +290,3 @@ Full documentation: **[docs/advanced-docs.md](docs/advanced-docs.md)**
 ## 📄 License
 
 MIT
-


### PR DESCRIPTION
## Summary
- Replaces the minimal unprotected-dashboard setup with a **secure-by-default** Quick Start: SSO/OAuth2, basic auth, IP allow-listing, UFW firewall, fail2ban, and monitoring are now part of the default install instructions.
- LUKS at-rest encryption and S3 backups are documented as optional hardening steps (they require a dedicated disk volume and S3 credentials respectively).
- Removes the "⚠️ Security Notice" disclaimer that framed the insecure minimal setup as the default. The repo's purpose is a ready-to-use, full-featured Supabase with security, encryption, and SSO/auth — the README now reflects that as the default path while staying simple and complete.

## Design
- [x] Design canvas not needed (docs-only change, no UI/architecture)

## Test Plan
- [x] Test cases not applicable (README documentation change)
- [x] Build passes — N/A (no code/build for this repo's docs)
- [x] Unit tests pass — N/A
- [ ] CI checks pass
- [x] Code simplification review — N/A (prose only)
- [ ] PR review agent review passed
- [ ] Reviewer bot findings addressed (REVIEW_BOTS empty — skipped)
- [ ] E2E tests — N/A (docs)

## Checklist
- [x] Documentation updated (README rewritten)
- [x] Internal links verified (`docs/advanced-docs.md` exists, `#sso-provider-setup` anchor matches the `#### SSO Provider Setup` heading)

Closes #89