### PR TITLE
feat(setup): add env lock to prevent secret clobber on re-run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ These are problems encountered while building this repo, and how they were fixed
 - **`set_env_var` uses `sed` on `key: value` lines — never run it on a list variable**, it corrupts the YAML (e.g. `docker_users`). For lists, replace only the `- item` line and leave the key line untouched.
 - **When a rendered value may be empty or a placeholder, guard the write** with `[[ -n "$val" ]]` so template rendering doesn't break.
 - **Regenerate the whole playbook from component toggles** — never edit it line-by-line/uncomment fragments.
+- **Secret regeneration on a second `setup.sh` run breaks running Supabase services** (issue #127). The first successful render writes `env/.setup.lock`; subsequent runs skip the entire secrets block (whether `secrets.generate: true` or `false`) so the existing keys in `env/supabase.yml` are preserved byte-for-byte. `--force` overrides and regenerates. `--dry-run` never writes the lock. `generate-keys.sh` honors the same lock (`--force` to override). Never `set_env_var` a secrets field without first checking `ENV_LOCKED`/`FORCE`, or you reintroduce the clobber.
 
 ### Monitoring
 - **Promtail's push URL must have a valid scheme** (`http://loki:3100/...`, not `http//loki:3100`).

--- a/README.md
+++ b/README.md
@@ -107,8 +107,11 @@ That's it. `setup.sh` will:
 |------|-------------|
 | `--dry-run` | Preview what would happen without modifying any files |
 | `--yes` | Non-interactive (skip confirmation prompts) — ideal for CI/AI agents |
+| `--force` | Regenerate secrets even if `env/supabase.yml` is already locked |
 | `-v, --verbose` | Verbose output |
 | `-h, --help` | Show help |
+
+> **Locking:** after the first successful render, `setup.sh` writes `env/.setup.lock`. Subsequent runs **preserve the existing secrets** in `env/supabase.yml` — they are neither regenerated nor overwritten with placeholders — so already-running Supabase services keep working. Pass `--force` to regenerate secrets on purpose (e.g. after a key rotation). `--dry-run` never writes the lock.
 
 ```bash
 # Preview without changes

--- a/config.example.yml
+++ b/config.example.yml
@@ -48,6 +48,12 @@ required:
 # By default these are auto-generated on first run. Most users leave this alone.
 # Set `generate: false` ONLY if you want to provide your own keys (e.g. migrating
 # an existing stack).
+#
+# LOCKING: after the first successful run, setup.sh writes env/.setup.lock.
+# On subsequent runs the secrets in env/supabase.yml are PRESERVED as-is —
+# they are NOT regenerated and NOT overwritten with placeholders — so running
+# Supabase services keep working. To force regeneration (e.g. you rotated
+# keys on purpose), run:  sudo bash setup.sh --force
 secrets:
   generate: true
   # The values below are used ONLY when generate: false. Leave as changeit otherwise.

--- a/docs/test-cases/setup-locking.md
+++ b/docs/test-cases/setup-locking.md
@@ -1,0 +1,94 @@
+# Test Cases: Setup Locking System (Issue #127)
+
+## Goal
+
+Prevent `setup.sh` from regenerating secrets (or clobbering an already-rendered
+`env/supabase.yml` with the vanilla template) on a second run, unless the user
+explicitly forces regeneration with `--force`.
+
+## Background
+
+Two failure modes the locking system must prevent:
+
+1. **Secret overwrite on second run** — `secrets.generate: true` on a second
+   `setup.sh` run generates fresh keys and overwrites the ones already in
+   `env/supabase.yml`. Supabase services already configured with the old keys
+   crash (JWT verification fails, DB password mismatch, etc.).
+2. **Vanilla template clobber when generation disabled** — setting
+   `secrets.generate: false` (without providing values) makes `setup.sh` write
+   `changeit` placeholders back into `env/supabase.yml`, destroying the
+   previously-generated secrets.
+
+## Locking Mechanism
+
+A lock file `env/.setup.lock` is written after the first successful render of
+`env/supabase.yml`. On subsequent runs, if the lock file exists and `--force`
+was NOT passed:
+
+- The secrets block is skipped entirely (no `set_env_var` calls for any
+  `secrets.*` field), preserving whatever is already in `env/supabase.yml`.
+- A clear `[lock]` log line tells the user the env is locked and how to
+  override (`--force`).
+
+`--force` regenerates everything as if it were the first run (and rewrites the
+lock file). `--dry-run` never writes or touches the lock file.
+
+## Test Cases
+
+### TC-LOCK-001: First run writes lock file
+**Preconditions:** Fresh sandbox, no `env/.setup.lock`, valid `config.yml`,
+`secrets.generate: true`.
+**Steps:** Run `setup.sh --yes`.
+**Expected:** Exit 0; `env/.setup.lock` exists; secrets in `env/supabase.yml`
+are non-`changeit`.
+
+### TC-LOCK-002: Second run preserves secrets (no --force)
+**Preconditions:** TC-LOCK-001 state (lock file exists, secrets generated).
+**Steps:** Run `setup.sh --yes` again.
+**Expected:** Exit 0; secrets in `env/supabase.yml` are byte-identical to the
+values after the first run; output contains a `[lock]` notice.
+
+### TC-LOCK-003: --force regenerates secrets
+**Preconditions:** TC-LOCK-001 state.
+**Steps:** Run `setup.sh --yes --force`.
+**Expected:** Exit 0; at least one secret in `env/supabase.yml` differs from
+the pre-run value (regenerated); lock file rewritten.
+
+### TC-LOCK-004: Disabling generation does NOT clobber existing secrets
+**Preconditions:** TC-LOCK-001 state; then set `secrets.generate: false` in
+`config.yml` (leave `secrets.*` values as `changeit`).
+**Steps:** Run `setup.sh --yes`.
+**Expected:** Exit 0; secrets in `env/supabase.yml` are unchanged (still the
+generated values from the first run, NOT `changeit`); output contains `[lock]`
+notice.
+
+### TC-LOCK-005: --dry-run never writes a lock file
+**Preconditions:** Fresh sandbox, no lock file, valid `config.yml`.
+**Steps:** Run `setup.sh --dry-run --yes`.
+**Expected:** Exit 0; `env/.setup.lock` does NOT exist.
+
+### TC-LOCK-006: --force on first run behaves like normal first run
+**Preconditions:** Fresh sandbox, no lock file.
+**Steps:** Run `setup.sh --yes --force`.
+**Expected:** Exit 0; lock file created; secrets generated.
+
+### TC-LOCK-007: Lock file is valid JSON with expected fields
+**Preconditions:** TC-LOCK-001 state.
+**Expected:** `env/.setup.lock` parses as JSON and contains at minimum a
+`rendered_at` timestamp and the `config_file` path.
+
+### TC-LOCK-008: generate-keys.sh refuses without --force when lock exists
+**Preconditions:** TC-LOCK-001 state (lock file exists).
+**Steps:** Run `generate-keys.sh` (no args).
+**Expected:** Non-zero exit; prints a message instructing to use `--force`;
+`env/supabase.yml` secrets unchanged.
+
+### TC-LOCK-009: generate-keys.sh --force regenerates when lock exists
+**Preconditions:** TC-LOCK-001 state.
+**Steps:** Run `generate-keys.sh --force`.
+**Expected:** Exit 0; secrets regenerated (differ from pre-run values).
+
+### TC-LOCK-010: generate-keys.sh runs freely when no lock exists
+**Preconditions:** Fresh sandbox, no lock file.
+**Steps:** Run `generate-keys.sh`.
+**Expected:** Exit 0; secrets generated.

--- a/generate-keys.sh
+++ b/generate-keys.sh
@@ -1,8 +1,36 @@
 #!/bin/sh
 # Generate secrets and write them directly into env/supabase.yml
-# Usage:  cd ansible-supabase  &&  sh generate-keys.sh
+# Usage:
+#   sh generate-keys.sh           # generate (refuses if env is locked)
+#   sh generate-keys.sh --force   # regenerate even if env is locked
+#
+# Locking: if env/.setup.lock exists, this script refuses to run unless
+# --force is passed — regenerating secrets breaks running Supabase services
+# that were configured with the old keys (issue #127).
 
 set -e
+
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    -h|--help)
+      echo "Usage: sh generate-keys.sh [--force]"
+      echo "  --force   Regenerate secrets even if env/.setup.lock exists"
+      exit 0
+      ;;
+    *) echo "Unknown option: $arg" >&2; exit 2 ;;
+  esac
+done
+
+LOCK_FILE="env/.setup.lock"
+if [ -f "$LOCK_FILE" ] && [ "$FORCE" -eq 0 ]; then
+  echo "error: env is locked ($LOCK_FILE exists)." >&2
+  echo "       Regenerating secrets would break running Supabase services." >&2
+  echo "       Re-run with --force to override:" >&2
+  echo "         sh generate-keys.sh --force" >&2
+  exit 1
+fi
 
 gen_hex()    { openssl rand -hex "$1"; }
 gen_b64()    { openssl rand -base64 "$1"; }

--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,13 @@
 #   sudo bash setup.sh              # generate + deploy
 #   bash setup.sh --dry-run         # preview without modifying files
 #   bash setup.sh --yes             # non-interactive (AI-friendly)
+#   bash setup.sh --force           # regenerate secrets even if env is locked
 #   bash setup.sh --help
+# =============================================================================
+# Locking: after the first successful render of env/supabase.yml, a lock file
+# (env/.setup.lock) is written. On subsequent runs, the secrets block is
+# skipped (preserving the already-rendered secrets) unless --force is passed.
+# This prevents overwriting keys that running Supabase services depend on.
 # =============================================================================
 
 set -euo pipefail
@@ -23,10 +29,12 @@ EXAMPLE_CONFIG="${SCRIPT_DIR}/config.example.yml"
 ENV_FILE="${SCRIPT_DIR}/env/supabase.yml"
 PLAYBOOK_FILE="${SCRIPT_DIR}/playbook-supabase.yml"
 GENERATE_KEYS="${SCRIPT_DIR}/generate-keys.sh"
+LOCK_FILE="${SCRIPT_DIR}/env/.setup.lock"
 
 DRY_RUN=0
 ASSUME_YES=0
 VERBOSE=0
+FORCE=0
 
 # ─── Colors ──────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -39,6 +47,7 @@ log()     { printf "${BLUE}[setup]${NC} %s\n" "$*"; }
 ok()      { printf "${GREEN}[ok]${NC} %s\n" "$*"; }
 warn()    { printf "${YELLOW}[warn]${NC} %s\n" "$*" >&2; }
 die()     { printf "${RED}[error]${NC} %s\n" "$*" >&2; exit 1; }
+locklog() { printf "${YELLOW}[lock]${NC} %s\n" "$*"; }
 
 # ─── Help ────────────────────────────────────────────────────────────────────
 usage() {
@@ -51,6 +60,7 @@ Usage:
 Options:
   --dry-run        Preview actions without modifying any files
   --yes            Non-interactive (skip confirmation prompts) — for AI/CI
+  --force          Regenerate secrets even if env/supabase.yml is already locked
   -v, --verbose    Verbose output
   -h, --help       Show this help and exit
 
@@ -73,6 +83,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run)  DRY_RUN=1; shift ;;
     --yes)      ASSUME_YES=1; shift ;;
+    --force)    FORCE=1; shift ;;
     -v|--verbose) VERBOSE=1; shift ;;
     -h|--help)  usage; exit 0 ;;
     *) die "Unknown option: $1 (try --help)" ;;
@@ -286,8 +297,32 @@ if [[ -n "$deploy_env" && "$deploy_env" != "changeit" ]]; then
   set_env_var "deploy_env" "$deploy_env"
 fi
 
+# ─── Lock detection ──────────────────────────────────────────────────────────
+# A lock file (env/.setup.lock) marks that env/supabase.yml has already been
+# rendered with secrets. On a second run we MUST NOT regenerate or clobber
+# those secrets — running Supabase services depend on them. --force overrides.
+ENV_LOCKED=0
+if [[ -f "$LOCK_FILE" ]]; then
+  ENV_LOCKED=1
+  if [[ $FORCE -eq 1 ]]; then
+    locklog "Lock file found but --force given; secrets will be regenerated."
+  else
+    locklog "env/supabase.yml is already rendered (lock: $LOCK_FILE)."
+    locklog "Secrets will be preserved. Run with --force to regenerate them."
+  fi
+fi
+
 # Secrets
-if cfg_bool "secrets.generate"; then
+if [[ $ENV_LOCKED -eq 1 && $FORCE -eq 0 ]]; then
+  # Locked and not forced: skip the entire secrets block so the existing
+  # values in env/supabase.yml are left untouched. This covers BOTH failure
+  # modes from issue #127:
+  #   1. secrets.generate: true  → would overwrite existing keys with fresh
+  #      ones, breaking running services.
+  #   2. secrets.generate: false → would write `changeit` placeholders back
+  #      over the previously-generated secrets, clobbering them.
+  log "Skipping secret generation (env is locked)."
+elif cfg_bool "secrets.generate"; then
   log "Auto-generating cryptographic secrets…"
   jwt_secret="$(gen_b64 30)"
   iat="$(date +%s)"
@@ -417,6 +452,24 @@ PYEOF
 fi
 
 ok "env/supabase.yml rendered."
+
+# ─── Write lock file ─────────────────────────────────────────────────────────
+# Mark env/supabase.yml as rendered so subsequent runs don't clobber secrets.
+# The lock is a small JSON record. --force rewrites it; --dry-run never does.
+python3 - "$LOCK_FILE" "$CONFIG_FILE" <<'PYEOF'
+import sys, json, os, time
+lock_path, cfg_path = sys.argv[1], sys.argv[2]
+record = {
+    "rendered_at": int(time.time()),
+    "config_file": cfg_path,
+    "note": "env/supabase.yml has been rendered with secrets. Re-run setup.sh with --force to regenerate.",
+}
+os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+with open(lock_path, "w") as f:
+    json.dump(record, f, indent=2)
+    f.write("\n")
+PYEOF
+ok "Lock written: $LOCK_FILE"
 
 # ─── Playbook component toggling ─────────────────────────────────────────────
 # Regenerate playbook-supabase.yml deterministically from the component toggles.

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -26,11 +26,13 @@ make_sandbox() {
   cp "$WORKTREE/setup.sh" "$WORKTREE/config.example.yml" "$WORKTREE/install.sh" \
      "$WORKTREE/generate-keys.sh" "$WORKTREE/playbook-supabase.yml" "$d/" 2>/dev/null
   cp "$WORKTREE/env/supabase.yml" "$d/env/"
+  # Remove any stale lock file copied from the real env/ (tests manage it explicitly)
+  rm -f "$d/env/.setup.lock"
   cat > "$d/install.sh" <<'STUB'
 #!/bin/bash
 echo "STUBBED_INSTALL_OK"
 STUB
-  chmod +x "$d/install.sh" "$d/setup.sh"
+  chmod +x "$d/install.sh" "$d/setup.sh" "$d/generate-keys.sh"
   echo "$d"
 }
 
@@ -245,6 +247,156 @@ if [[ $RC -eq 0 ]]; then
   fi
 else
   fail "setup.sh failed with monitor enabled (rc=$RC)"
+  echo "$OUT" | tail -20
+fi
+
+# ─── TC-LOCK-001: First run writes lock file ──────────────────────────────────
+echo "TC-LOCK-001: first run writes lock file"
+d="$(make_sandbox tc_lock_001)"
+cp "$d/config.example.yml" "$d/config.yml"
+fill_required "$d"
+rm -f "$d/env/.setup.lock"
+run_setup_rc "$d" --yes
+if [[ $RC -eq 0 && -f "$d/env/.setup.lock" ]] \
+  && ! grep -q "^postgres_db_pwd: changeit" "$d/env/supabase.yml"; then
+  ok "first run creates lock file and generates secrets"
+else
+  fail "first run did not create lock file or generate secrets (rc=$RC)"
+  echo "$OUT" | tail -20
+fi
+
+# ─── TC-LOCK-002: Second run preserves secrets (no --force) ───────────────────
+echo "TC-LOCK-002: second run preserves secrets"
+# Reuse tc_lock_001 sandbox (lock file + secrets already in place)
+pwd_before="$(grep '^postgres_db_pwd:' "$d/env/supabase.yml" | awk '{print $2}')"
+jwt_before="$(grep '^sb_jwt_secret:' "$d/env/supabase.yml" | awk '{print $2}')"
+run_setup_rc "$d" --yes
+pwd_after="$(grep '^postgres_db_pwd:' "$d/env/supabase.yml" | awk '{print $2}')"
+jwt_after="$(grep '^sb_jwt_secret:' "$d/env/supabase.yml" | awk '{print $2}')"
+if [[ $RC -eq 0 && "$pwd_before" == "$pwd_after" && "$jwt_before" == "$jwt_after" ]] \
+  && echo "$OUT" | grep -q "\[lock\]"; then
+  ok "second run preserves secrets and prints [lock] notice"
+else
+  fail "second run changed secrets or missing [lock] notice (rc=$RC)"
+  echo "  pwd: $pwd_before -> $pwd_after"
+  echo "  jwt: $jwt_before -> $jwt_after"
+fi
+
+# ─── TC-LOCK-003: --force regenerates secrets ─────────────────────────────────
+echo "TC-LOCK-003: --force regenerates secrets"
+# Reuse tc_lock_001 sandbox
+pwd_before="$(grep '^postgres_db_pwd:' "$d/env/supabase.yml" | awk '{print $2}')"
+run_setup_rc "$d" --yes --force
+pwd_after="$(grep '^postgres_db_pwd:' "$d/env/supabase.yml" | awk '{print $2}')"
+if [[ $RC -eq 0 && "$pwd_before" != "$pwd_after" ]] \
+  && ! grep -q "^postgres_db_pwd: changeit" "$d/env/supabase.yml"; then
+  ok "--force regenerates secrets (postgres_db_pwd changed)"
+else
+  fail "--force did not regenerate secrets (rc=$RC, changed=$([[ $pwd_before == $pwd_after ]] && echo no || echo yes))"
+fi
+
+# ─── TC-LOCK-004: Disabling generation does NOT clobber existing secrets ──────
+echo "TC-LOCK-004: secrets.generate=false does not clobber locked env"
+d="$(make_sandbox tc_lock_004)"
+cp "$d/config.example.yml" "$d/config.yml"
+fill_required "$d"
+run_setup_rc "$d" --yes   # first run: generate + lock
+pwd_before="$(grep '^postgres_db_pwd:' "$d/env/supabase.yml" | awk '{print $2}')"
+jwt_before="$(grep '^sb_jwt_secret:' "$d/env/supabase.yml" | awk '{print $2}')"
+# Now disable generation (leave secrets.* as changeit in config)
+sed -i 's|generate: true|generate: false|' "$d/config.yml"
+run_setup_rc "$d" --yes
+pwd_after="$(grep '^postgres_db_pwd:' "$d/env/supabase.yml" | awk '{print $2}')"
+jwt_after="$(grep '^sb_jwt_secret:' "$d/env/supabase.yml" | awk '{print $2}')"
+if [[ $RC -eq 0 && "$pwd_before" == "$pwd_after" && "$jwt_before" == "$jwt_after" ]] \
+  && echo "$OUT" | grep -q "\[lock\]"; then
+  ok "generate=false preserves locked secrets (no clobber)"
+else
+  fail "generate=false clobbered locked secrets (rc=$RC)"
+  echo "  pwd: $pwd_before -> $pwd_after"
+  echo "  jwt: $jwt_before -> $jwt_after"
+fi
+
+# ─── TC-LOCK-005: --dry-run never writes a lock file ──────────────────────────
+echo "TC-LOCK-005: dry-run never writes lock file"
+d="$(make_sandbox tc_lock_005)"
+cp "$d/config.example.yml" "$d/config.yml"
+fill_required "$d"
+rm -f "$d/env/.setup.lock"
+run_setup_rc "$d" --dry-run --yes
+if [[ $RC -eq 0 && ! -f "$d/env/.setup.lock" ]]; then
+  ok "dry-run does not create lock file"
+else
+  fail "dry-run created a lock file (rc=$RC, exists=$([ -f "$d/env/.setup.lock" ] && echo yes || echo no))"
+fi
+
+# ─── TC-LOCK-006: --force on first run behaves like normal first run ──────────
+echo "TC-LOCK-006: --force on first run"
+d="$(make_sandbox tc_lock_006)"
+cp "$d/config.example.yml" "$d/config.yml"
+fill_required "$d"
+rm -f "$d/env/.setup.lock"
+run_setup_rc "$d" --yes --force
+if [[ $RC -eq 0 && -f "$d/env/.setup.lock" ]] \
+  && ! grep -q "^postgres_db_pwd: changeit" "$d/env/supabase.yml"; then
+  ok "--force on first run creates lock + generates secrets"
+else
+  fail "--force on first run failed (rc=$RC)"
+  echo "$OUT" | tail -20
+fi
+
+# ─── TC-LOCK-007: Lock file is valid JSON with expected fields ────────────────
+echo "TC-LOCK-007: lock file is valid JSON"
+d="$(make_sandbox tc_lock_007)"
+cp "$d/config.example.yml" "$d/config.yml"
+fill_required "$d"
+run_setup_rc "$d" --yes
+if [[ $RC -eq 0 ]] && python3 -c "import json,sys; \
+   d=json.load(open('$d/env/.setup.lock')); \
+   assert 'rendered_at' in d and 'config_file' in d" 2>/dev/null; then
+  ok "lock file is valid JSON with rendered_at + config_file"
+else
+  fail "lock file is not valid JSON or missing fields (rc=$RC)"
+fi
+
+# ─── TC-LOCK-008: generate-keys.sh refuses without --force when locked ────────
+echo "TC-LOCK-008: generate-keys.sh refuses when locked"
+d="$(make_sandbox tc_lock_008)"
+cp "$d/config.example.yml" "$d/config.yml"
+fill_required "$d"
+run_setup_rc "$d" --yes   # create lock + secrets
+pwd_before="$(grep '^postgres_db_pwd:' "$d/env/supabase.yml" | awk '{print $2}')"
+OUT="$( cd "$d" && sh generate-keys.sh 2>&1 )" && RC=$? || RC=$?
+pwd_after="$(grep '^postgres_db_pwd:' "$d/env/supabase.yml" | awk '{print $2}')"
+if [[ $RC -ne 0 && "$pwd_before" == "$pwd_after" ]] && echo "$OUT" | grep -qi "force"; then
+  ok "generate-keys.sh refuses when locked and mentions --force"
+else
+  fail "generate-keys.sh did not refuse when locked (rc=$RC, changed=$([[ $pwd_before == $pwd_after ]] && echo no || echo yes))"
+fi
+
+# ─── TC-LOCK-009: generate-keys.sh --force regenerates when locked ────────────
+echo "TC-LOCK-009: generate-keys.sh --force regenerates"
+# Reuse tc_lock_008 sandbox
+pwd_before="$(grep '^postgres_db_pwd:' "$d/env/supabase.yml" | awk '{print $2}')"
+OUT="$( cd "$d" && sh generate-keys.sh --force 2>&1 )" && RC=0 || RC=$?
+pwd_after="$(grep '^postgres_db_pwd:' "$d/env/supabase.yml" | awk '{print $2}')"
+if [[ $RC -eq 0 && "$pwd_before" != "$pwd_after" ]]; then
+  ok "generate-keys.sh --force regenerates secrets when locked"
+else
+  fail "generate-keys.sh --force did not regenerate (rc=$RC, changed=$([[ $pwd_before == $pwd_after ]] && echo no || echo yes))"
+fi
+
+# ─── TC-LOCK-010: generate-keys.sh runs freely when no lock exists ────────────
+echo "TC-LOCK-010: generate-keys.sh runs when no lock"
+d="$(make_sandbox tc_lock_010)"
+cp "$d/config.example.yml" "$d/config.yml"
+fill_required "$d"
+rm -f "$d/env/.setup.lock"
+OUT="$( cd "$d" && sh generate-keys.sh 2>&1 )" && RC=0 || RC=$?
+if [[ $RC -eq 0 ]] && ! grep -q "^postgres_db_pwd: changeit" "$d/env/supabase.yml"; then
+  ok "generate-keys.sh runs without lock and generates secrets"
+else
+  fail "generate-keys.sh failed without lock (rc=$RC)"
   echo "$OUT" | tail -20
 fi
 


### PR DESCRIPTION
## Summary

- Add a locking system (`env/.setup.lock`) so `setup.sh` does **not** regenerate or clobber secrets in `env/supabase.yml` on a second run — preventing the crash of already-configured Supabase services.
- `--force` flag overrides the lock and regenerates secrets on purpose (e.g. key rotation). `--dry-run` never writes the lock.
- `generate-keys.sh` honors the same lock (`--force` to override).

## What problem this fixes

Issue #127 described two failure modes:

1. **Secret overwrite on second run** — `secrets.generate: true` on a second `setup.sh` run generates fresh keys and overwrites the old ones in `env/supabase.yml`. Supabase services already configured with the old keys crash (JWT verification fails, DB password mismatch, etc.).
2. **Vanilla template clobber when generation disabled** — setting `secrets.generate: false` (without providing values) makes `setup.sh` write `changeit` placeholders back over the previously-generated secrets, destroying them.

Both are now fixed: after the first successful render, a lock file (`env/.setup.lock`) is written. On subsequent runs the **entire secrets block is skipped** (whether `secrets.generate` is `true` or `false`), so the existing keys are preserved byte-for-byte. `--force` overrides and regenerates.

## Design

- [x] Design canvas created (`docs/test-cases/setup-locking.md` — full test-case spec)

## Test Plan

- [x] Test cases documented (`docs/test-cases/setup-locking.md`)
- [x] Build passes (`bash tests/test-setup.sh` — 23/23 pass: 13 existing + 10 new TC-LOCK-*)
- [x] Unit tests pass (TC-LOCK-001..010 cover first run, second-run preservation, `--force`, `generate=false` clobber prevention, dry-run, lock file JSON validity, and `generate-keys.sh` lock behavior)
- [x] CI checks pass
- [x] Code simplification review passed (small, focused change; no dead code)
- [x] PR review agent review passed
- [x] Reviewer bot findings addressed (no new findings)
- [x] E2E tests pass (no E2E suite — `E2E_MODE=command` no-op per project config)

## Checklist

- [x] New unit tests written for new functionality (10 TC-LOCK-* cases)
- [x] Documentation updated (`config.example.yml`, `README.md`, `AGENTS.md`)
- [x] `--force` and `--dry-run` semantics documented in `--help`

Closes #127
