### PR TITLE
feat(supabase): enable/disable individual supabase services via config.yml

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -45,6 +45,21 @@ required:
   # Set to false if you don't want Supabase log drain logging inside the dashboard.
   enable_logging: true
 
+  # Supabase services — toggle each on/off before deploying.
+  # db (Postgres) and kong (API gateway) are always required and are not listed.
+  # Disabling a service also removes its depends_on edges; Kong routes for a
+  # disabled service remain defined (they will 502 until the service is enabled).
+  services:
+    auth: true        # GoTrue (email/phone/OAuth sign-in)
+    rest: true        # PostgREST (/rest/v1 REST API, /graphql/v1)
+    realtime: true    # Realtime (websockets)
+    storage: true     # Storage API (file storage)
+    imgproxy: true    # Image transformation (used by storage)
+    functions: true   # Edge Functions
+    studio: true      # Dashboard (Studio)
+    meta: true        # pg-meta (Studio SQL editor / schema)
+    supavisor: true   # Connection pooler (port 6543)
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # SECRETS  —  Cryptographic keys for Supabase internals.

--- a/env/supabase.yml
+++ b/env/supabase.yml
@@ -54,6 +54,19 @@ kong_conf_path: volumes/api
 # docker-compose-logs.yml; set to false to disable log drain in the dashboard.
 log_drain_enabled: true
 
+# Supabase services — toggled by setup.sh from required.services. Each gates
+# the corresponding service in docker-compose-supabase.yml.j2. db (Postgres)
+# and kong (API gateway) are always required and have no toggle here.
+auth_enabled: true
+rest_enabled: true
+realtime_enabled: true
+storage_enabled: true
+imgproxy_enabled: true
+functions_enabled: true
+studio_enabled: true
+meta_enabled: true
+supavisor_enabled: true
+
 # MCP (Model Context Protocol) secure access.
 # The /mcp Kong route is restricted to these IPs only. Docker source-NATs
 # host-originated connections to the bridge gateway IP (172.28.0.1 - see the

--- a/roles/supabase/templates/docker-compose-supabase.yml.j2
+++ b/roles/supabase/templates/docker-compose-supabase.yml.j2
@@ -1,6 +1,7 @@
 name: supabase
 
 services:
+{% if studio_enabled | default(true) | bool %}
   studio:
     container_name: supabase-studio{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_studio_version }}
@@ -49,6 +50,7 @@ services:
     volumes:
       - ./volumes/snippets:/app/snippets:z
       - ./volumes/functions:/app/edge-functions:ro,z
+{% endif %}
 
   kong:
     container_name: supabase-kong{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
@@ -64,8 +66,10 @@ services:
       timeout: 5s
       retries: 5
     depends_on:
+      {% if studio_enabled | default(true) | bool %}
       studio:
         condition: service_healthy
+      {% endif %}
     ports:
       - ${KONG_HTTP_PORT}:8000/tcp
       - ${KONG_HTTPS_PORT}:8443/tcp
@@ -98,6 +102,7 @@ services:
       KONG_PORT_MAPS: "443:8000"
     entrypoint: ["/bin/sh", "/home/kong/kong-entrypoint.sh"]
 
+{% if auth_enabled | default(true) | bool %}
 
   auth:
     container_name: supabase-auth{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
@@ -260,7 +265,9 @@ services:
       # GOTRUE_HOOK_SEND_EMAIL_ENABLED: "false"
       # GOTRUE_HOOK_SEND_EMAIL_URI: "http://host.docker.internal:54321/functions/v1/email_sender"
       # GOTRUE_HOOK_SEND_EMAIL_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
+{% endif %}
 
+{% if rest_enabled | default(true) | bool %}
   rest:
     container_name: supabase-rest{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_rest_version }}
@@ -295,7 +302,9 @@ services:
       [
         "postgrest"
       ]
+{% endif %}
 
+{% if realtime_enabled | default(true) | bool %}
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
@@ -336,8 +345,10 @@ services:
       SEED_SELF_HOST: "true"
       RUN_JANITOR: "true"
       DISABLE_HEALTHCHECK_LOGGING: "true"
+{% endif %}
 
 
+  {% if storage_enabled | default(true) | bool %}
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
     container_name: supabase-storage{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
@@ -347,10 +358,14 @@ services:
       db:
         # Disable this if you are using an external Postgres database
         condition: service_healthy
+      {% if rest_enabled | default(true) | bool %}
       rest:
         condition: service_started
+      {% endif %}
+      {% if imgproxy_enabled | default(true) | bool %}
       imgproxy:
         condition: service_started
+      {% endif %}
     healthcheck:
       test:
         [
@@ -397,7 +412,9 @@ services:
       S3_PROTOCOL_ACCESS_KEY_SECRET: ${S3_PROTOCOL_ACCESS_KEY_SECRET}
     volumes:
       - ./volumes/storage:/var/lib/storage:z
+{% endif %}
 
+{% if imgproxy_enabled | default(true) | bool %}
   imgproxy:
     container_name: supabase-imgproxy{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_imgproxy_version }}
@@ -420,7 +437,9 @@ services:
       IMGPROXY_USE_ETAG: "true"
       IMGPROXY_AUTO_WEBP: ${IMGPROXY_AUTO_WEBP}
       IMGPROXY_MAX_SRC_RESOLUTION: 16.8
+{% endif %}
 
+{% if meta_enabled | default(true) | bool %}
   meta:
     container_name: supabase-meta{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_meta_version }}
@@ -437,7 +456,9 @@ services:
       PG_META_DB_USER: postgres
       PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
       CRYPTO_KEY: ${PG_META_CRYPTO_KEY}  
+{% endif %}
 
+{% if functions_enabled | default(true) | bool %}
   functions:
     container_name: supabase-edge-functions{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_functions_version }}
@@ -473,6 +494,7 @@ services:
         "--main-service",
         "/home/deno/functions/main"
       ]
+{% endif %}
 
 
 
@@ -569,6 +591,7 @@ services:
   # Update the DATABASE_URL if you are using an external Postgres database
 
 
+{% if supavisor_enabled | default(true) | bool %}
   supavisor:
     container_name: supabase-pooler{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_supavisor_version }}
@@ -631,6 +654,7 @@ services:
         "-c",
         "/app/bin/migrate && /app/bin/supavisor eval \"$$(cat /etc/pooler/pooler.exs)\" && /app/bin/server"
       ]
+{% endif %}
 
 volumes:
   db-config:

--- a/roles/supabase/templates/docker-compose-supabase.yml.j2
+++ b/roles/supabase/templates/docker-compose-supabase.yml.j2
@@ -65,12 +65,10 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-    depends_on:
-      {% if studio_enabled | default(true) | bool %}
+{% if studio_enabled | default(true) | bool %}    depends_on:
       studio:
         condition: service_healthy
-      {% endif %}
-    ports:
+{% endif %}    ports:
       - ${KONG_HTTP_PORT}:8000/tcp
       - ${KONG_HTTPS_PORT}:8443/tcp
     volumes:
@@ -348,25 +346,22 @@ services:
 {% endif %}
 
 
-  {% if storage_enabled | default(true) | bool %}
-  # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
+{% if storage_enabled | default(true) | bool %}  # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
     container_name: supabase-storage{{ '-' + deploy_env if deploy_env != 'changeit' else '' }}
     image: {{ sb_storage_version }}
     restart: unless-stopped
-    depends_on:
+{% if storage_enabled | default(true) | bool %}    depends_on:
       db:
         # Disable this if you are using an external Postgres database
         condition: service_healthy
-      {% if rest_enabled | default(true) | bool %}
-      rest:
+{% if rest_enabled | default(true) | bool %}      rest:
         condition: service_started
-      {% endif %}
-      {% if imgproxy_enabled | default(true) | bool %}
-      imgproxy:
+{% endif %}
+{% if imgproxy_enabled | default(true) | bool %}      imgproxy:
         condition: service_started
-      {% endif %}
-    healthcheck:
+{% endif %}
+{% endif %}    healthcheck:
       test:
         [
           "CMD",

--- a/setup.sh
+++ b/setup.sh
@@ -342,6 +342,15 @@ log_drain="$(cfg_get "required.enable_logging")"
 [[ -z "$log_drain" ]] && log_drain="true"
 set_env_var "log_drain_enabled" "$log_drain"
 
+# Supabase services — toggle each on/off before deploying. Defaults to true when
+# the field is missing so upgraded configs keep every service. db and kong are
+# always required and have no toggle (they are not read nor listed here).
+for svc in auth rest realtime storage imgproxy functions studio meta supavisor; do
+  val="$(cfg_get "required.services.${svc}")"
+  [[ -z "$val" ]] && val="true"
+  set_env_var "${svc}_enabled" "$val"
+done
+
 # docker_users is a list; the template has `- changeit` under it. Replace the
 # first list item line (do NOT touch the `docker_users:` key — it must stay a list).
 sed -i "s|^  - changeit.*|  - $(cfg_get "required.deploy_user")|" "$ENV_FILE"


### PR DESCRIPTION
## Summary

Closes #145 — add the ability to toggle individual Supabase services on/off from `config.yml` before deploying.

Adds a `required.services:` block in `config.yml` (9 booleans, all default `true`) covering: `auth`, `rest`, `realtime`, `storage`, `imgproxy`, `functions`, `studio`, `meta`, `supavisor`. `db` (Postgres) and `kong` (API gateway) are always required and are not listed.

## What changed

- **`config.example.yml`** — new `required.services:` block (all default `true`).
- **`env/supabase.yml`** — seeded the nine `<name>_enabled: true` Ansible vars.
- **`setup.sh`** — a loop reads `required.services.<name>` (defaulting to `true` if missing) and writes each via `set_env_var`, following the existing `require.enable_logging` pattern. Existing configs are unaffected (everything stays on).
- **`roles/supabase/templates/docker-compose-supabase.yml.j2`** — each of the nine service blocks is wrapped in `{% if <name>_enabled | default(true) | bool %} … {% endif %}`. Orphaned `depends_on` edges are also gated: `kong→studio`, `storage→rest`, `storage→imgproxy`. `db` and `kong` stay unconditional.

## Guarantees & behavior

- **All-enabled output is byte-identical to the pre-change template** (automated render comparison passes), so the default deploy is unchanged.
- Disabling a service removes its container and its `depends_on` edges; compose still starts cleanly; `start-supabase.sh` health polling is unaffected (it counts only running services).
- **Kong routes for a disabled service remain defined** and return `502` until the service is re-enabled (gateway routing is deliberately out of scope here).

## Known behavior notes

- `studio: false` also breaks the `/mcp` and `/api/mcp` Kong routes (they target studio → 502).
- `meta: false` → Studio runs but its SQL editor/schema view doesn't (Studio calls `http://meta:8080`).
- `imgproxy: false` → storage runs but image transformation is unavailable at runtime.

## Testing

- `setup.sh` passes `bash -n`.
- `config.example.yml` and `env/supabase.yml` parse as valid YAML.
- Template render-check script validates: all-enabled == HEAD (byte-identical) and YAML parses for every toggle combination, with `db`/`kong` always present.