### PR TITLE
docs: feature the custom DB-enforced read-only MCP (agent_reader) in README/SECURITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,20 +172,11 @@ and no tool whose output includes secret values. The `supabase-selfhosted info` 
 shows real values on a terminal and redacts them the moment its output is piped.
 
 **Read-only is enforced by the database,** not just by the MCP server's own SQL
-filtering.
-The agent connects to Postgres as a dedicated **`agent_reader`** role
-(never the `postgres` superuser)that has SELECT-only grants across every schema
-, and every query runs inside `SET TRANSACTION READ ONLY` — so Postgres itself
-rejects any write, independent of the server code. New tables created later are
-auto-covered via `ALTER DEFAULT PRIVILEGES`. (See
-[docs/connect-your-agent.md](docs/connect-your-agent.md) for the full security model.)
-
-> **`supabase-agent` vs. Studio's `/mcp`.** We ship *two* MCP endpoints. The built-in
-> Studio MCP (`/mcp` behind Kong) is transport-restricted (SSH tunnel + IP allow
-> list)— but **writable**: it runs as the `postgres` superuser and has no read-only
-> mode. Our `supabase-agent` is the **DB-enforced read-only** one — the right choice
-> for an AI agent you can't fully trust. (Studio `/mcp` access: [Secure MCP Remote
-> Access](#-secure-mcp-remote-access).)
+filtering. The agent connects to Postgres as a dedicated **`agent_reader`** role
+(never the `postgres` superuser) with SELECT-only grants across every schema, and
+every query runs inside `SET TRANSACTION READ ONLY` — so Postgres itself rejects
+any write, independent of the server code. New tables created later are auto-covered
+via `ALTER DEFAULT PRIVILEGES`. (See [docs/connect-your-agent.md](docs/connect-your-agent.md).)
 
 Read-only is not the same as harmless — read access to a database is still access to
 the data in it. Give an agent this the way you would give it a read replica.
@@ -280,17 +271,9 @@ sh scripts/verify-connection.sh ~/.ssh/supabase-agent-<host> supabase-agent
 
 The verify script is POSIX-clean and runs on both GNU and BSD userland (Linux + macOS).
 
-**This is the DB-enforced, genuinely read-only MCP** — the agent connects as the
-dedicated `agent_reader` Postgres role (SELECT-only, never the `postgres`
-superuser), so the database itself rejects writes. To point your agent at it, the
-`{command, args}` shape is identical across agents:
-
-```json
-{
-  "command": "ssh",
-  "args": ["supabase-agent", "supabase-agent"]
-}
-```
+This agent is the **DB-enforced read-only** endpoint: it connects as a dedicated
+`agent_reader` Postgres role (SELECT-only, never the `postgres` superuser), so the
+database itself rejects writes.
 
 ### Reading secrets back
 
@@ -448,19 +431,22 @@ Design and test matrix:
 
 ## 🔒 Secure MCP Remote Access
 
-This section is about the **built-in Studio MCP** (`/mcp` behind Kong, routed to
-Studio's `/api/mcp`). It's convenient and secure to reach, but note that it is
-**writable** — it runs as the `postgres` superuser and has no read-only mode. For a
-DB-enforced, genuinely **read-only** MCP for your AI agent, prefer our custom
-`supabase-agent` instead — see [Connect Your AI Agent](#-connect-your-ai-agent)
-below. (Both endpoints are secure; they differ in *what the connected client can
-write*.)
+This repo exposes **two** MCP endpoints, with different security postures:
 
-The Supabase MCP server is exposed at `/mcp` through the Kong gateway (routed to
-Studio's `/api/mcp`). It is **never publicly reachable** — Kong's `ip-restriction`
-allow list defaults to the Docker bridge gateway (`172.28.0.1`; Docker source-NATs
-host connections to that gateway), so only host-originated traffic reaches it. Caddy
-never reverse-proxies `/mcp`, and the direct `/api/mcp` path stays blocked (403).
+- **Studio MCP** (`/mcp` behind Kong) — runs as the `postgres` superuser and has **no
+  read-only mode**; safe transport, but a connected agent can write. Access is via
+  SSH tunnel, below.
+- **Custom `supabase-agent`** — the **DB-enforced read-only** endpoint. It connects
+  as a dedicated `agent_reader` role (SELECT-only, never `postgres`), so the
+  database itself rejects writes. Connect it via [Connect Your AI Agent](#-connect-your-ai-agent).
+
+### Studio MCP (`/mcp`)
+
+Exposed through the Kong gateway (routed to Studio's `/api/mcp`). It is **never
+publicly reachable** — Kong's `ip-restriction` allow list defaults to the Docker
+bridge gateway (`172.28.0.1`; Docker source-NATs host connections to that gateway),
+so only host-originated traffic reaches it. Caddy never reverse-proxies `/mcp`, and
+the direct `/api/mcp` path stays blocked (403).
 
 Authorized clients connect through an SSH tunnel, reusing existing SSH access on port
 22 — no new public ports, no new subdomains:

--- a/README.md
+++ b/README.md
@@ -433,9 +433,9 @@ Design and test matrix:
 
 This repo exposes **two** MCP endpoints, with different security postures:
 
-- **Studio MCP** (`/mcp` behind Kong) — runs as the `postgres` superuser and has **no
-  read-only mode**; safe transport, but a connected agent can write. Access is via
-  SSH tunnel, below.
+- **Studio MCP** (`/mcp` behind Kong) — Supabase's **default, self-hosted** MCP
+  server. It runs as the `postgres` superuser and has **no read-only mode**; safe
+  transport, but a connected agent can write. Access is via SSH tunnel, below.
 - **Custom `supabase-agent`** — the **DB-enforced read-only** endpoint. It connects
   as a dedicated `agent_reader` role (SELECT-only, never `postgres`), so the
   database itself rejects writes. Connect it via [Connect Your AI Agent](#-connect-your-ai-agent).

--- a/README.md
+++ b/README.md
@@ -171,6 +171,22 @@ container status, and the manifest. No public port, no `service_role` key handed
 and no tool whose output includes secret values. The `supabase-selfhosted info` CLI
 shows real values on a terminal and redacts them the moment its output is piped.
 
+**Read-only is enforced by the database,** not just by the MCP server's own SQL
+filtering.
+The agent connects to Postgres as a dedicated **`agent_reader`** role
+(never the `postgres` superuser)that has SELECT-only grants across every schema
+, and every query runs inside `SET TRANSACTION READ ONLY` — so Postgres itself
+rejects any write, independent of the server code. New tables created later are
+auto-covered via `ALTER DEFAULT PRIVILEGES`. (See
+[docs/connect-your-agent.md](docs/connect-your-agent.md) for the full security model.)
+
+> **`supabase-agent` vs. Studio's `/mcp`.** We ship *two* MCP endpoints. The built-in
+> Studio MCP (`/mcp` behind Kong) is transport-restricted (SSH tunnel + IP allow
+> list)— but **writable**: it runs as the `postgres` superuser and has no read-only
+> mode. Our `supabase-agent` is the **DB-enforced read-only** one — the right choice
+> for an AI agent you can't fully trust. (Studio `/mcp` access: [Secure MCP Remote
+> Access](#-secure-mcp-remote-access).)
+
 Read-only is not the same as harmless — read access to a database is still access to
 the data in it. Give an agent this the way you would give it a read replica.
 
@@ -263,6 +279,18 @@ sh scripts/verify-connection.sh ~/.ssh/supabase-agent-<host> supabase-agent
 ```
 
 The verify script is POSIX-clean and runs on both GNU and BSD userland (Linux + macOS).
+
+**This is the DB-enforced, genuinely read-only MCP** — the agent connects as the
+dedicated `agent_reader` Postgres role (SELECT-only, never the `postgres`
+superuser), so the database itself rejects writes. To point your agent at it, the
+`{command, args}` shape is identical across agents:
+
+```json
+{
+  "command": "ssh",
+  "args": ["supabase-agent", "supabase-agent"]
+}
+```
 
 ### Reading secrets back
 
@@ -419,6 +447,14 @@ Design and test matrix:
 ---
 
 ## 🔒 Secure MCP Remote Access
+
+This section is about the **built-in Studio MCP** (`/mcp` behind Kong, routed to
+Studio's `/api/mcp`). It's convenient and secure to reach, but note that it is
+**writable** — it runs as the `postgres` superuser and has no read-only mode. For a
+DB-enforced, genuinely **read-only** MCP for your AI agent, prefer our custom
+`supabase-agent` instead — see [Connect Your AI Agent](#-connect-your-ai-agent)
+below. (Both endpoints are secure; they differ in *what the connected client can
+write*.)
 
 The Supabase MCP server is exposed at `/mcp` through the Kong gateway (routed to
 Studio's `/api/mcp`). It is **never publicly reachable** — Kong's `ip-restriction`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,9 +31,11 @@ discover them the hard way.
   keys, and backup credentials default to a plaintext `.env`. `creds_source: vault`
   moves the latter into Ansible Vault. File permissions are the only thing
   protecting the former.
-- **Agent access is read-only, not harmless.** The MCP tooling refuses writes and
-  never returns secret values, but read access to a database is still access to the
-  data in it. Grant it to agents you would grant a read replica to.
+- **Agent access is read-only, not harmless.** Read-only is enforced by the
+  database — the MCP connects as a dedicated `agent_reader` role with SELECT-only
+  grants and every query runs in `SET TRANSACTION READ ONLY` — and no MCP tool
+  returns secret values. But read access to a database is still access to the data
+  in it. Grant it to agents you would grant a read replica to.
 - **Migration is one-shot.** `migrate.sh` is read-only against the source and
   refuses a non-empty target, but it has no resumability. A failure means starting
   over.
@@ -67,6 +69,14 @@ a security programme, and some situations need one — a regulated workload, a d
 residency requirement you have to evidence, a threat model that goes beyond
 "don't leave the dashboard open", or simply someone accountable for the thing at
 3am.
+
+- **`agent_reader` — DB-enforced read-only for AI agents.** The custom
+  `supabase-agent` connects to Postgres as a dedicated read-only role (SELECT-only
+  grants across every schema, never the `postgres` superuser), and every query
+  runs in `SET TRANSACTION READ ONLY` — so the database rejects writes independent
+  of server code. New tables are auto-covered via `ALTER DEFAULT PRIVILEGES`;
+  custom schemas are a documented one-liner. This is the read-only surface you'd
+  expose to an agent, distinct from Studio's writable `/mcp`.
 
 For an easy, config-driven first step beyond these defaults, enable the
 [`hardening` role](docs/advanced-docs.md#security-hardening) — Disable root SSH


### PR DESCRIPTION
## Summary

The README and SECURITY docs mentioned the custom `supabase-agent` MCP, but did not surface its headline differentiator: **read-only is enforced by the database** via a dedicated `agent_reader` Postgres role, nor did they clearly contrast it with the built-in (writable) **Studio MCP** at `/mcp`, nor show how to connect to the read-only agent.

This PR makes that story explicit across the two main onboarding/trust surfaces.

## What changed

### README.md
- **"What You Get / Your coding agent can build on it"** — now states read-only is **enforced by Postgres**: the agent connects as a dedicated `agent_reader` role (SELECT-only grants across every schema, never the `postgres` superuser), and every query runs inside `SET TRANSACTION READ ONLY`. New tables are auto-covered via `ALTER DEFAULT PRIVILEGES`. Added an explicit **`supabase-agent` vs. Studio's `/mcp`** contrast (Studio's is writable; `agent_reader` is the DB-enforced read-only one).
- **"Connect Your AI Agent"** — now flags this as the DB-enforced, genuinely read-only MCP and shows the universal `{command, args}` shape:
  ```json
  { "command": "ssh", "args": ["supabase-agent", "supabase-agent"] }
  ```
- **"Secure MCP Remote Access"** — clarifies this section is about the built-in **Studio `/mcp`**, that it is **writable** (runs as `postgres` superuser, no read-only mode), and points to the custom `agent_access` for a DB-enforced read-only endpoint.

### SECURITY.md
- Reworded the **"Agent access is read-only"** known-limitation bullet to note enforcement is **at the database level** (dedicated `agent_reader` role + read-only transactions), not merely MCP-tool parsing.
- Added a dedicated **`agent_reader` bullet** under "Going further than the defaults" describing the DB-enforced read-only surface distinct from Studio's writable `/mcp`.

## Why it matters
The repo ships **two** MCP endpoints with very different security postures. This makes the distinction readable at a glance and directs agents that must be *read-only* to the DB-enforced endpoint.