### PR TITLE
feat(supabase): raise realtime tenant rate limits

### DIFF
--- a/roles/supabase/tasks/main.yml
+++ b/roles/supabase/tasks/main.yml
@@ -333,3 +333,26 @@
 
 - name: Start Supabase
   command: "bash /home/{{ deploy_user }}/{{ supabase_path }}/start-supabase.sh"
+
+# --- Realtime tenant rate limits ---------------------------------------------
+# Realtime throttles postgres-change events per tenant to 100/s by default.
+# Bulk mining writes persons faster than that, so realtime drops events
+# ("MessagePerSecondRateLimitReached") and the credits/profile channel in the
+# same cluster can be starved. The per-tenant limits live in _realtime.tenants,
+# which is owned by the supabase_admin superuser — the non-superuser migration
+# runner cannot update it — so apply idempotently here through the local db
+# container. Realtime's tenant cache expires (~60s default), so the raised
+# limits are picked up without a container restart.
+- name: Raise realtime tenant rate limits
+  ansible.builtin.shell: >-
+    docker exec
+    supabase-db{{ '-' + deploy_env | default('changeit') if deploy_env | default('changeit') != 'changeit' else '' }}
+    psql -U supabase_admin -d postgres -v ON_ERROR_STOP=1 -c
+    "UPDATE _realtime.tenants
+       SET max_events_per_second = 1000, max_bytes_per_second = 1000000
+       WHERE max_events_per_second <> 1000 OR max_bytes_per_second <> 1000000;"
+  register: realtime_limits_result
+  changed_when: "'UPDATE 1' in realtime_limits_result.stdout"
+  # A brand-new volume has no tenant row until the first realtime boot; the next
+  # deploy after first boot applies the limits.
+  failed_when: false


### PR DESCRIPTION
## Summary

Raises the realtime tenant rate limits on the self-hosted Supabase stack. The default `100 events/s` per tenant is too low for the Leadminer bulk-mining workload: mining upserts `private.persons` faster than that, so realtime logs `MessagePerSecondRateLimitReached` and drops events — which also starves the credits/profile channel in the same cluster.

## Change

In `roles/supabase/tasks/main.yml`, after the stack starts:

```
docker exec supabase-db-{env} psql -U supabase_admin -d postgres -c \
  "UPDATE _realtime.tenants
     SET max_events_per_second = 1000, max_bytes_per_second = 1000000
     WHERE max_events_per_second <> 1000 OR max_bytes_per_second <> 1000000;"
```

Why this shape:
- `_realtime.tenants` is owned by the `supabase_admin` superuser; the non-superuser migration runner cannot update it, so the tweak belongs here (the role already runs `docker exec` into the same `supabase-db{-env}` container for the pgbackrest prep).
- Idempotent via the `WHERE` guard — `changed_when` only reports change on first apply.
- No container restart needed: realtime's tenant cache expires (~60s default), so the raised limits are picked up automatically.
- On a brand-new volume before the first realtime boot the tenant row doesn't exist yet; the next deploy after first boot applies it (`failed_when: false`).

## Testing

- `yamllint` clean (only pre-existing line-length warnings elsewhere in the file).
- `ansible-lint` clean (production profile, 0 failures/0 warnings).
- Verified the exact command against the QA instance with a `BEGIN … ROLLBACK` (`supabase_admin` can update `_realtime.tenants`; the container name resolves to `supabase-db-qa` / `supabase-db-prod` via `deploy_env`).
